### PR TITLE
Moved CursorDataExtractor and ContentValuesPopulator to package datastore

### DIFF
--- a/src/java/com/sarality/app/datastore/AbstractContentResolverDataStore.java
+++ b/src/java/com/sarality/app/datastore/AbstractContentResolverDataStore.java
@@ -8,7 +8,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.util.Log;
 
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 public abstract class AbstractContentResolverDataStore<T> extends AbstractDataStore<T> implements DataStore<T> {

--- a/src/java/com/sarality/app/datastore/AbstractDataStore.java
+++ b/src/java/com/sarality/app/datastore/AbstractDataStore.java
@@ -3,8 +3,6 @@ package com.sarality.app.datastore;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-
 /**
  * Abstract class that provides the base implementation for all {@link DataStore}s.
  * <p>
@@ -48,7 +46,6 @@ public abstract class AbstractDataStore<T> implements DataStore<T> {
     return columnList;
   }
 
-  @Override
   public final CursorDataExtractor<T> getCursorDataExtractor() {
     return extractor;
   }

--- a/src/java/com/sarality/app/datastore/AbstractWritableDataStore.java
+++ b/src/java/com/sarality/app/datastore/AbstractWritableDataStore.java
@@ -2,9 +2,6 @@ package com.sarality.app.datastore;
 
 import java.util.List;
 
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
-
 /**
  * Abstract class that provides the base implementation for a writable version of {@link DataStore}, where items can be
  * updated or inserted.

--- a/src/java/com/sarality/app/datastore/ContentValuesPopulator.java
+++ b/src/java/com/sarality/app/datastore/ContentValuesPopulator.java
@@ -1,4 +1,4 @@
-package com.sarality.app.datastore.populator;
+package com.sarality.app.datastore;
 
 import android.content.ContentValues;
 

--- a/src/java/com/sarality/app/datastore/CursorDataExtractor.java
+++ b/src/java/com/sarality/app/datastore/CursorDataExtractor.java
@@ -1,4 +1,4 @@
-package com.sarality.app.datastore.extractor;
+package com.sarality.app.datastore;
 
 import android.database.Cursor;
 

--- a/src/java/com/sarality/app/datastore/DataStore.java
+++ b/src/java/com/sarality/app/datastore/DataStore.java
@@ -2,7 +2,6 @@ package com.sarality.app.datastore;
 
 import java.util.List;
 
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 /**
@@ -45,9 +44,4 @@ public interface DataStore<T> {
    * @return  {@code List} of {@code DataObject}s matching the query.
    */
   public List<T> query(Query query);
-
-  /**
-   * @return The class that convert the cursor returned by the DataStore into a DataObject.
-   */
-  public CursorDataExtractor<T> getCursorDataExtractor();
 }

--- a/src/java/com/sarality/app/datastore/WritableDataStore.java
+++ b/src/java/com/sarality/app/datastore/WritableDataStore.java
@@ -1,7 +1,6 @@
 package com.sarality.app.datastore;
 
 import com.sarality.app.data.DataObject;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
 import com.sarality.app.datastore.query.Query;
 
 /**
@@ -35,11 +34,5 @@ public interface WritableDataStore<T, I> extends DataStore<T> {
    * @param data The data with the updated values.
    * @param query Query to define the set of items that need to be updated.
    */
-  public void update(T data, Query query);
-  
-  /**
-   * @return A class that populates values in the {@code ContentValues} needed to insert
-   * or update data in a data store.
-   */
-  public ContentValuesPopulator<T> getContentValuesPopulator();
+  public void update(T data, Query query);  
 }

--- a/src/java/com/sarality/app/datastore/db/SqliteTable.java
+++ b/src/java/com/sarality/app/datastore/db/SqliteTable.java
@@ -16,8 +16,8 @@ import android.database.sqlite.SQLiteDatabase;
 import com.sarality.app.data.DataObject;
 import com.sarality.app.datastore.AbstractWritableDataStore;
 import com.sarality.app.datastore.Column;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
+import com.sarality.app.datastore.ContentValuesPopulator;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 /**

--- a/src/java/com/sarality/app/datastore/field/FieldBasedContentValuesPopulator.java
+++ b/src/java/com/sarality/app/datastore/field/FieldBasedContentValuesPopulator.java
@@ -6,10 +6,10 @@ import com.sarality.app.data.field.Field;
 import com.sarality.app.data.field.FieldContainer;
 import com.sarality.app.data.field.FieldContainerFactory;
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.ContentValuesPopulator;
 import com.sarality.app.datastore.FieldColumnMapping;
 import com.sarality.app.datastore.FieldColumnMappingList;
 import com.sarality.app.datastore.column.ColumnProcessor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
 
 /**
  * Generic implementation of the ContentValuesPopulator that uses Field and FieldContainers to populate a ContentValues

--- a/src/java/com/sarality/app/datastore/field/FieldBasedCursorDataExtractor.java
+++ b/src/java/com/sarality/app/datastore/field/FieldBasedCursorDataExtractor.java
@@ -6,10 +6,10 @@ import com.sarality.app.data.field.Field;
 import com.sarality.app.data.field.FieldContainer;
 import com.sarality.app.data.field.FieldContainerFactory;
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.FieldColumnMapping;
 import com.sarality.app.datastore.FieldColumnMappingList;
 import com.sarality.app.datastore.column.ColumnProcessor;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 /**

--- a/src/java/com/sarality/app/datastore/sms/SmsDataStore.java
+++ b/src/java/com/sarality/app/datastore/sms/SmsDataStore.java
@@ -11,9 +11,9 @@ import com.sarality.app.datastore.AbstractContentResolverDataStore;
 import com.sarality.app.datastore.ColumnDataType;
 import com.sarality.app.datastore.ColumnFormat;
 import com.sarality.app.datastore.ColumnSpec;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.column.ColumnProcessor;
 import com.sarality.app.datastore.column.ColumnProcessors;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 import com.sarality.app.datastore.sms.SmsMessage.MessageType;
 

--- a/tests/src/com/sarality/app/datastore/db/test/SqliteTableTest.java
+++ b/tests/src/com/sarality/app/datastore/db/test/SqliteTableTest.java
@@ -23,12 +23,12 @@ import com.sarality.app.common.collect.Lists;
 import com.sarality.app.datastore.Column;
 import com.sarality.app.datastore.ColumnDataType;
 import com.sarality.app.datastore.ColumnSpec;
+import com.sarality.app.datastore.ContentValuesPopulator;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.db.SqliteTable;
 import com.sarality.app.datastore.db.SqliteTableSchemaUpdater;
 import com.sarality.app.datastore.db.TableColumnProperty;
 import com.sarality.app.datastore.db.TableInfo;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
 import com.sarality.app.datastore.query.Query;
 
 /**

--- a/tests/src/com/sarality/app/datastore/db/test/TestTable.java
+++ b/tests/src/com/sarality/app/datastore/db/test/TestTable.java
@@ -5,10 +5,10 @@ import java.util.List;
 import android.app.Application;
 
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.ContentValuesPopulator;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.db.SqliteTable;
 import com.sarality.app.datastore.db.SqliteTableSchemaUpdater;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
 
 class TestTable extends SqliteTable<TestObject> {
   protected TestTable(Application application, String dbName, String tableName, int tableVersion,

--- a/tests/src/com/sarality/app/datastore/test/AbstractContentResolverDataStoreTest.java
+++ b/tests/src/com/sarality/app/datastore/test/AbstractContentResolverDataStoreTest.java
@@ -17,8 +17,8 @@ import android.test.mock.MockContentResolver;
 import com.sarality.app.common.collect.Lists;
 import com.sarality.app.datastore.AbstractContentResolverDataStore;
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.db.test.TestObject;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 /**

--- a/tests/src/com/sarality/app/datastore/test/AbstractDataStoreTest.java
+++ b/tests/src/com/sarality/app/datastore/test/AbstractDataStoreTest.java
@@ -13,8 +13,8 @@ import org.robolectric.RobolectricTestRunner;
 import com.sarality.app.common.collect.Lists;
 import com.sarality.app.datastore.AbstractDataStore;
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.db.test.TestObject;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
 import com.sarality.app.datastore.query.Query;
 
 /**

--- a/tests/src/com/sarality/app/datastore/test/AbstractWritableDataStoreTest.java
+++ b/tests/src/com/sarality/app/datastore/test/AbstractWritableDataStoreTest.java
@@ -13,9 +13,9 @@ import org.robolectric.RobolectricTestRunner;
 import com.sarality.app.common.collect.Lists;
 import com.sarality.app.datastore.AbstractWritableDataStore;
 import com.sarality.app.datastore.Column;
+import com.sarality.app.datastore.ContentValuesPopulator;
+import com.sarality.app.datastore.CursorDataExtractor;
 import com.sarality.app.datastore.db.test.TestObject;
-import com.sarality.app.datastore.extractor.CursorDataExtractor;
-import com.sarality.app.datastore.populator.ContentValuesPopulator;
 import com.sarality.app.datastore.query.Query;
 
 /**


### PR DESCRIPTION
Moved CursorDataExtractor and ContentValuesPopulator to package datastore since the sub packages

now only had the interfaces.

Also removed from DataStore interface accessors for both since this is only an implementation detail.
