### PR TITLE
Setup Action now moved to BaseAction from ComponentActionManager

### DIFF
--- a/src/java/com/sarality/app/view/action/BaseViewAction.java
+++ b/src/java/com/sarality/app/view/action/BaseViewAction.java
@@ -3,6 +3,9 @@ package com.sarality.app.view.action;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import android.view.View;
 
 import com.sarality.app.common.collect.Lists;
@@ -17,6 +20,8 @@ import com.sarality.app.common.collect.Lists;
  */
 public abstract class BaseViewAction implements ViewAction {
 
+  private static final Logger logger = LoggerFactory.getLogger(BaseViewAction.class);
+  
   // The Id of the view that triggers the action
   private final int viewId;
 
@@ -75,6 +80,37 @@ public abstract class BaseViewAction implements ViewAction {
     completeActionList.addAll(failureActionList);
     completeActionList.addAll(beforeActionList);
     return completeActionList;
+  }
+
+  @Override
+  public void setupAction(View view) {
+    View actionView = view.findViewById(getViewId());
+    if (actionView == null) {
+      String message = "Invalid Configuration for " + getTriggerType() + " Event. No View with Id "
+          + Integer.toHexString(getViewId()) + " found in view " + Integer.toHexString(view.getId());
+      IllegalStateException exception = new IllegalStateException(message);
+      logger.error(message, exception);
+      throw exception;
+    }
+    setActionPerformer(actionView);
+  }
+
+  /**
+   * Sets up the Action performer for a particular kind of trigger
+   * 
+   * @param layout layout view on which the actions are set
+   */
+  private void setActionPerformer(View view) {
+    if (triggerType == TriggerType.CLICK) {
+      new ClickActionPerformer(this).setupListener(view);
+    } else if (triggerType == TriggerType.LONG_CLICK) {
+      new LongClickActionPerformer(this).setupListener(view);
+    } else if (triggerType == TriggerType.TOUCH || triggerType == TriggerType.TOUCH_DOWN
+        || triggerType == TriggerType.TOUCH_UP) {
+      new TouchActionPerformer(this).setupListener(view);
+    } else if (triggerType == TriggerType.CLICK_LIST_ITEM) {
+      new ListItemClickActionPerformer(this).setupListener(view);
+    }
   }
 
   public abstract boolean doAction(View view, ViewActionTrigger actionDetail, ViewDetail viewDetail);

--- a/src/java/com/sarality/app/view/action/ComponentActionManager.java
+++ b/src/java/com/sarality/app/view/action/ComponentActionManager.java
@@ -4,13 +4,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import android.util.Log;
 import android.view.View;
 
 public class ComponentActionManager {
-
-  // Tag for Logging
-  private static final String TAG = "ComponentActionManager";
 
   // Map of View ID and compositeView Action
   private final Map<ViewTrigger, ViewAction> viewMap;
@@ -63,33 +59,7 @@ public class ComponentActionManager {
    */
   public void setupActions(View layout) {
     for (ViewAction action : viewMap.values()) {
-      View view = layout.findViewById(action.getViewId());
-      if (view == null) {
-        String message = "Invalid Configuration for " + action.getTriggerType() + " Event. No View with Id "
-            + Integer.toHexString(action.getViewId()) + " found in row " + Integer.toHexString(layout.getId());
-        IllegalStateException exception = new IllegalStateException(message);
-        Log.e(TAG, message, exception);
-        throw exception;
-      }
-      setActionPerformer(view, action);
-    }
-  }
-
-  /**
-   * Sets up the Action performer for a particular kind of trigger
-   * 
-   * @param layout layout view on which the actions are set
-   */
-  private void setActionPerformer(View view, ViewAction action) {
-    if (action.getTriggerType() == TriggerType.CLICK) {
-      new ClickActionPerformer(action).setupListener(view);
-    } else if (action.getTriggerType() == TriggerType.LONG_CLICK) {
-      new LongClickActionPerformer(action).setupListener(view);
-    } else if (action.getTriggerType() == TriggerType.TOUCH || action.getTriggerType() == TriggerType.TOUCH_DOWN
-        || action.getTriggerType() == TriggerType.TOUCH_UP) {
-      new TouchActionPerformer(action).setupListener(view);
-    } else if (action.getTriggerType() == TriggerType.CLICK_LIST_ITEM) {
-      new ListItemClickActionPerformer(action).setupListener(view);
+      action.setupAction(layout);
     }
   }
 }

--- a/src/java/com/sarality/app/view/action/ViewAction.java
+++ b/src/java/com/sarality/app/view/action/ViewAction.java
@@ -25,6 +25,12 @@ public interface ViewAction {
    */
   public TriggerType getTriggerType();
 
+  /**
+   * Sets up the action for the given view, 
+   * 
+   * @param view The view on which the action is being configured.
+   */
+  public void setupAction(View view);
 
   /**
    * Perform the action


### PR DESCRIPTION
This way we can call is directly without having to use ComponentActionManager
everywhere. In some cases like fragments it is not even available.
