### PR TITLE
Add a loader in the EnumDataRegistry so that we can load EnumData

### DIFF
--- a/src/java/com/sarality/app/data/EnumDataLoader.java
+++ b/src/java/com/sarality/app/data/EnumDataLoader.java
@@ -1,0 +1,17 @@
+package com.sarality.app.data;
+
+/**
+ * Interface to load an EnumData from a Persistent store.
+ *
+ * @author abhideep@ (Abhideep Singh)
+ */
+public interface EnumDataLoader<E extends EnumData<E>> {
+
+  /**
+   * Load the EnumData from the persistent store.
+   *
+   * @param name Unique name of the Enum.
+   * @return The EnumData with the given name if one is found, {@code null} otherwise.
+   */
+  public E load(String name);
+}


### PR DESCRIPTION
from a table rather than just an enum.

The good thing with this appraoch is that the Enum is still loaded the same way
via the EnumDataRegistry. All the loading from the Table is hidden from the caller

We can add support for multiple loaders in the future if needed.
