### PR TITLE
Use SenderId rather than entire address for looking up Extractors.

### DIFF
--- a/src/java/com/sarality/app/extract/SmsMessageEventExtractor.java
+++ b/src/java/com/sarality/app/extract/SmsMessageEventExtractor.java
@@ -1,6 +1,5 @@
 package com.sarality.app.extract;
 
-import com.sarality.app.common.collect.Sets;
 import com.sarality.app.datastore.sms.SmsMessage;
 
 import java.util.Set;
@@ -14,20 +13,16 @@ import java.util.regex.Pattern;
  */
 public abstract class SmsMessageEventExtractor<E> implements MessageEventExtractor<SmsMessage, E> {
 
-  private final Set<String> senders;
+  private final Set<String> senderIds;
   private final Pattern messagePattern;
 
-  public SmsMessageEventExtractor(Set<String> senders, String messagePattern) {
-    this.senders = toUpperCase(senders);
+  public SmsMessageEventExtractor(Set<String> senderIdSet, String messagePattern) {
+    this.senderIds = senderIdSet;
     this.messagePattern = Pattern.compile(messagePattern);
   }
 
-  public SmsMessageEventExtractor(String messagePattern) {
-    this(Sets.<String>emptySet(), messagePattern);
-  }
-
-  protected Set<String> getSenders() {
-    return senders;
+  protected Set<String> getSenderIds() {
+    return senderIds;
   }
 
   protected Matcher createMatcher(SmsMessage message) {
@@ -36,16 +31,5 @@ public abstract class SmsMessageEventExtractor<E> implements MessageEventExtract
 
   protected boolean matchesPattern(Matcher matcher) {
     return matcher.lookingAt();
-  }
-
-  private static Set<String> toUpperCase(Set<String> senders) {
-    if (senders == null) {
-      return null;
-    }
-    Set<String> upperCaseSender = Sets.emptySet();
-    for (String sender : senders) {
-      upperCaseSender.add(sender.toUpperCase());
-    }
-    return upperCaseSender;
   }
 }

--- a/src/java/com/sarality/app/extract/SmsMessageEventExtractorProvider.java
+++ b/src/java/com/sarality/app/extract/SmsMessageEventExtractorProvider.java
@@ -23,8 +23,8 @@ public abstract class SmsMessageEventExtractorProvider {
   }
 
   public final List<SmsMessageEventExtractor<?>> provide(SmsMessage message) {
-    String sender = message.getAddress();
-    return eventExtractorMap.get(sender == null ? null : sender.toUpperCase());
+    String senderId = getSenderId(message.getAddress());
+    return eventExtractorMap.get(senderId.toUpperCase());
   }
 
   protected abstract void registerAllExtractors();
@@ -32,10 +32,10 @@ public abstract class SmsMessageEventExtractorProvider {
   /**
    * Register an extractor with the Provider.
    *
-   * @param extractor Extractpr to be used for SMS Messages
+   * @param extractor Extractor to be used for SMS Messages
    */
   protected final void register(SmsMessageEventExtractor<?> extractor) {
-    Set<String> senderSet = extractor.getSenders();
+    Set<String> senderSet = extractor.getSenderIds();
     if (senderSet != null) {
       for (String sender : senderSet) {
         if (!eventExtractorMap.containsKey(sender)) {
@@ -44,5 +44,22 @@ public abstract class SmsMessageEventExtractorProvider {
         eventExtractorMap.get(sender).add(extractor);
       }
     }
+  }
+
+  /**
+   * Retrieve the Extractor lookup key (SenderId) for the SMS messages address.
+   * <p/>
+   * The lookup is used for commercial message where the address follows a specific format e.g. AD-CLRTRIP or
+   * TM-MMTRIP, where the first two chars represent the Carrier and the City and the remaining address represents the
+   * Sender Id.
+   */
+  private String getSenderId(String address) {
+    if (address == null) {
+      return null;
+    }
+    if (address.length() < 4) {
+      return address.toUpperCase();
+    }
+    return address.substring(3).toUpperCase();
   }
 }


### PR DESCRIPTION
This both saves memory as well as avoids having to register all possible sender
names based on city and carrier combinations.